### PR TITLE
Handle invalid login

### DIFF
--- a/api/controllers/signin.js
+++ b/api/controllers/signin.js
@@ -12,12 +12,12 @@ export const handleSignIn = async (db, bcrypt) => async (req, res) => {
         console.log(err)
         res.status(400).json({
             status: "failed",
-            error: 'error loging in'
+            error: 'invalid credentials'
         })
     }
 }
 
-const getUserByEmailPassword = async (email, password, db, bcrypt) => {
+export const getUserByEmailPassword = async (email, password, db, bcrypt) => {
     const loginTableUser = await db
     .select('*')
     .from('login')
@@ -29,14 +29,16 @@ const getUserByEmailPassword = async (email, password, db, bcrypt) => {
     }
     
     const passwordIsValid = await bcrypt.compare(password, loginTableUser.hash);
-    
-    if (passwordIsValid) {
-        const user = await db
-        .select('*')
-        .from('users')
-        .where('email', '=', email)
-        .then(data => data[0])
-        
-        return user;
+
+    if (!passwordIsValid) {
+        throw new Error('invalid credentials');
     }
-} 
+
+    const user = await db
+    .select('*')
+    .from('users')
+    .where('email', '=', email)
+    .then(data => data[0])
+
+    return user;
+}

--- a/api/package.json
+++ b/api/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "node server.js",
-    "start:dev": "nodemon server.js"
+    "start:dev": "nodemon server.js",
+    "test": "node ./test/signin.test.js"
   },
   "author": "",
   "license": "ISC",

--- a/api/test/signin.test.js
+++ b/api/test/signin.test.js
@@ -1,0 +1,68 @@
+import assert from 'assert';
+import { getUserByEmailPassword, handleSignIn } from '../controllers/signin.js';
+
+const mockUser = { id: 1, email: 'test@example.com', name: 'Tester' };
+const loginRecord = { hash: 'hashed' };
+
+function createDb(passwordMatch = true) {
+  return {
+    select() {
+      return {
+        from: (table) => ({
+          where: () => ({
+            then: (cb) => Promise.resolve(cb([table === 'login' ? loginRecord : mockUser]))
+          })
+        })
+      };
+    },
+  };
+}
+
+function createBcrypt(passwordMatch = true) {
+  return {
+    compare: async () => passwordMatch,
+  };
+}
+
+async function runTests() {
+  // Successful retrieval
+  const user = await getUserByEmailPassword('test@example.com', 'secret', createDb(true), createBcrypt(true));
+  assert.deepStrictEqual(user, mockUser, 'should return user when password is valid');
+
+  // Failed retrieval
+  let threw = false;
+  try {
+    await getUserByEmailPassword('test@example.com', 'bad', createDb(true), createBcrypt(false));
+  } catch (err) {
+    threw = true;
+  }
+  assert.ok(threw, 'should throw when password is invalid');
+
+  // handleSignIn success
+  const reqSucc = { body: { email: 'test@example.com', password: 'secret' } };
+  let jsonResp;
+  const resSucc = {
+    json: (obj) => { jsonResp = obj; },
+    status: () => ({ json: () => {} }),
+  };
+  const handlerSucc = await handleSignIn(createDb(true), createBcrypt(true));
+  await handlerSucc(reqSucc, resSucc);
+  assert.deepStrictEqual(jsonResp.user, mockUser, 'handler should send user on success');
+
+  // handleSignIn failure
+  const reqFail = { body: { email: 'test@example.com', password: 'bad' } };
+  let statusCode;
+  let jsonFail;
+  const resFail = {
+    status: (code) => { statusCode = code; return { json: (obj) => { jsonFail = obj; } }; },
+    json: () => {},
+  };
+  const handlerFail = await handleSignIn(createDb(true), createBcrypt(false));
+  await handlerFail(reqFail, resFail);
+  assert.strictEqual(statusCode, 400, 'handler should respond with 400 on failure');
+  assert.strictEqual(jsonFail.error, 'invalid credentials', 'handler should send error message');
+
+  console.log('All tests passed');
+}
+
+runTests();

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders sign in form by default', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const legends = screen.getAllByText(/sign in/i);
+  expect(legends.length).toBeGreaterThan(0);
 });

--- a/frontend/src/components/Signin/SignIn.js
+++ b/frontend/src/components/Signin/SignIn.js
@@ -5,16 +5,17 @@ class Signin extends Component {
         super(props);
         this.state = {
             email: "",
-            password: ""
+            password: "",
+            error: ""
         }
     }
 
     updateEmailState = (e) => {
-        this.setState({email: e.target.value})
+        this.setState({email: e.target.value, error: ""})
     }
 
     updatePasswordState = (e) => {
-        this.setState({password: e.target.value})
+        this.setState({password: e.target.value, error: ""})
     }
 
     signIn = () => {
@@ -31,8 +32,11 @@ class Signin extends Component {
             if(data.user) {
                 this.props.loadUser(data.user);
                 this.props.setRoute('home');
+            } else if (data.error) {
+                this.setState({ error: data.error });
             }
         })
+        .catch(() => this.setState({ error: 'unable to sign in' }))
     }
     
     render() {
@@ -72,6 +76,9 @@ class Signin extends Component {
                                     />
                             </div>
                         </fieldset>
+                        {this.state.error && (
+                            <div className="mt2 red center">{this.state.error}</div>
+                        )}
                         <div className="center">
                             <input
                                 onClick={this.signIn}

--- a/frontend/src/components/Signin/SignIn.test.js
+++ b/frontend/src/components/Signin/SignIn.test.js
@@ -1,0 +1,39 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import Signin from './SignIn';
+
+describe('Signin', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  test('shows error message on failed login', async () => {
+    fetch.mockResolvedValue({
+      json: () => Promise.resolve({ error: 'invalid credentials' })
+    });
+
+    render(<Signin loadUser={jest.fn()} setRoute={jest.fn()} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'bad' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => screen.getByText(/invalid credentials/i));
+    expect(screen.getByText(/invalid credentials/i)).toBeInTheDocument();
+  });
+
+  test('calls loadUser on successful login', async () => {
+    fetch.mockResolvedValue({
+      json: () => Promise.resolve({ user: { id: 1 } })
+    });
+
+    const loadUser = jest.fn();
+    const setRoute = jest.fn();
+    render(<Signin loadUser={loadUser} setRoute={setRoute} />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@b.com' } });
+    fireEvent.change(screen.getByLabelText(/password/i), { target: { value: 'good' } });
+    fireEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => expect(loadUser).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Summary
- handle bad login passwords in sign in logic
- surface backend error message to users
- add unit tests for login success and failure
- fix failing default frontend test

## Testing
- `npm test` in api
- `npm install` in frontend
- `CI=true npm test --silent -- --watchAll=false` in frontend

------
https://chatgpt.com/codex/tasks/task_e_68416eb112b08333b4b5466d9f0451e4