### PR TITLE
Add API URL env variable

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://frozen-crag-50039.herokuapp.com

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,10 @@
 # FaceDetectionWebapp
+
+## Environment variables
+Create a `.env` file in this directory based on `.env.example` and set:
+
+```
+REACT_APP_API_URL=<backend url>
+```
+
+This variable defines the base URL used by the frontend when calling the API.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -46,7 +46,7 @@ class App extends Component {
     }
 
     updateBoundingBox = async (imgUrl) => {
-        fetch("https://frozen-crag-50039.herokuapp.com/facedetect", {
+        fetch(`${process.env.REACT_APP_API_URL}/facedetect`, {
         method: 'POST',
         headers: {'content-type' : 'application/json'},
         body: JSON.stringify({imgUrl: imgUrl})
@@ -59,7 +59,7 @@ class App extends Component {
 
     updateUserEntries = async () => {
         return(
-            fetch('https://frozen-crag-50039.herokuapp.com/image', {
+            fetch(`${process.env.REACT_APP_API_URL}/image`, {
                 method: 'put',
                 headers: {'content-type': 'application/json'},
                 body: JSON.stringify({id: this.state.user.id})

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders sign in form', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const linkElements = screen.getAllByText(/sign in/i);
+  expect(linkElements.length).toBeGreaterThan(0);
 });

--- a/frontend/src/components/Register/Register.js
+++ b/frontend/src/components/Register/Register.js
@@ -23,7 +23,7 @@ class Register extends Component {
     }
 
     register = () => {
-        fetch('https://frozen-crag-50039.herokuapp.com/register', {
+        fetch(`${process.env.REACT_APP_API_URL}/register`, {
             method: 'post',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({

--- a/frontend/src/components/Signin/SignIn.js
+++ b/frontend/src/components/Signin/SignIn.js
@@ -18,7 +18,7 @@ class Signin extends Component {
     }
 
     signIn = () => {
-        fetch('https://frozen-crag-50039.herokuapp.com/signin', {
+        fetch(`${process.env.REACT_APP_API_URL}/signin`, {
             method: "post",
             headers: {'content-type': 'application/json'},
             body: JSON.stringify({


### PR DESCRIPTION
## Summary
- add `REACT_APP_API_URL` example
- use the new env variable for API calls
- explain the new env variable in README
- update failing test to look for Sign In form

## Testing
- `npm ci --prefix frontend`
- `CI=true npm test --prefix frontend --silent`


------
https://chatgpt.com/codex/tasks/task_e_68416e9a841c833393c8d7ddd04770e5